### PR TITLE
eventlircd: do not handle power button

### DIFF
--- a/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
+++ b/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
@@ -63,10 +63,6 @@ SUBSYSTEMS=="rc", \
 #-------------------------------------------------------------------------------
 # Ask eventlircd to handle power button and input event devices.
 #-------------------------------------------------------------------------------
-SUBSYSTEMS=="acpi", ATTRS{hid}=="LNXPWRBN", \
-  ENV{eventlircd_enable}="true", \
-  ENV{eventlircd_evmap}="default.evmap"
-
 # WeTek Play (power button)
 SUBSYSTEMS=="input", ATTRS{name}=="key_input", \
   ENV{eventlircd_enable}="true", \


### PR DESCRIPTION
ACPI power keys are unconditionally handled by eventlircd. systemd-logind takes over after removing the UDEV rule.